### PR TITLE
Add offline dashboard

### DIFF
--- a/OnFrame/deviantart.py
+++ b/OnFrame/deviantart.py
@@ -2,10 +2,12 @@ import requests
 import random
 import shutil
 import json
-import urllib.request
 import os
 from PIL import Image
 from datetime import datetime
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WEB_DIR = os.path.join(BASE_DIR, "OnWeb")
 
 
 def deviantart():
@@ -29,42 +31,15 @@ def deviantart():
     # Retrieving access token from API response
     access_token = response.json()["access_token"]
 
-    ban_url_tag = "OnWeb.com/tags.json"
-    destination = "tags.json"
-
-    # Delete the old file if it exists
-    if os.path.exists(destination):
-        os.remove(destination)
-
-    # Download JSON file and save to specified destination
-    try:
-        urllib.request.urlretrieve("OnWeb.com/tags.json", "tags.json")
-        # print("Téléchargement réussi!")
-    except Exception as e:
-        print("Error downloading tags.json : ", e)
-
-    # Load tags from tags.json file
-    with open('tags.json', 'r') as f:
+    tags_path = os.path.join(WEB_DIR, 'tags.json')
+    with open(tags_path, 'r') as f:
         json_tag = json.load(f)['tag']
         convert_json_tag = [item['name'] for item in json_tag]
     tag = random.choice(convert_json_tag)
 
 
-    ban_url_tag = "OnWeb.com/bantag.json"
-    destination = "bantag.json"
-
-    # Delete the old file if it exists
-    if os.path.exists(destination):
-        os.remove(destination)
-
-    # Download JSON file and save to specified destination
-    try:
-        urllib.request.urlretrieve("OnWeb.com/bantag.json", "bantag.json")
-    except Exception as e:
-        print("Error downloading bantag.json : ", e)
-
-    # Load forbidden tags from bantag.json file
-    with open('bantag.json', 'r') as f:
+    bantag_path = os.path.join(WEB_DIR, 'bantag.json')
+    with open(bantag_path, 'r') as f:
         json_exclude_tag = json.load(f)['ban']
         convert_json_exclude_tag = [item['name'] for item in json_exclude_tag]
     exclude_tag = ", ".join(convert_json_exclude_tag)

--- a/OnFrame/download.py
+++ b/OnFrame/download.py
@@ -2,27 +2,20 @@ from deviantart import deviantart
 from fixed_download import fixed_download
 from plex import plex
 from display import display
-import requests
-import urllib.request
-import time
 import json
 import os
 
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WEB_DIR = os.path.join(BASE_DIR, "OnWeb")
+
 def download():
-    destination = "function.json"
+    destination = os.path.join(WEB_DIR, "function.json")
 
-    # Delete the old file if it exists
-    if os.path.exists(destination):
-        os.remove(destination)
+    if not os.path.exists(destination):
+        print("function.json not found")
+        return False
 
-    # Download JSON file and save to specified destination
-    try:
-        urllib.request.urlretrieve("OnWeb.com/function.json", "function.json")
-    except Exception as e:
-        print("Erreur lors du téléchargement function.json : ", e)
-
-
-    with open("function.json") as f:
+    with open(destination) as f:
         data = json.load(f)
     print(data["function"])
 

--- a/OnFrame/fixed_download.py
+++ b/OnFrame/fixed_download.py
@@ -1,10 +1,16 @@
-import urllib.request
-import requests
-#connect to OnWeb(your server) and download still
-def fixed_download():
-    url = "OnWeb.com/img.png"
-    filename = "img.png"
+import os
 
-    urllib.request.urlretrieve(url, filename)
+# Download the static image from the local web folder
+def fixed_download():
+    src = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                       'OnWeb', 'img.png')
+    dst = 'img.png'
+
+    if not os.path.exists(src):
+        print('img.png not found in OnWeb directory')
+        return False
+
+    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
+        fdst.write(fsrc.read())
     print("FIXED DOWNLOADED")
     return True

--- a/OnFrame/frame.service
+++ b/OnFrame/frame.service
@@ -2,7 +2,7 @@
 Description = Frame
 After = multi-user.target network.target
 [Service]
-ExecStart=/usr/bin/python /home/pi/Frame/main.py
+ExecStart=/usr/bin/python /home/pi/Frame/dashboard.py
 WorkingDirectory=/home/pi/Frame
 User=root
 Type=idle

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To fully use The Frame, open all the files and change the capitalized informatio
 ## OnFrame setup
 To properly configure the frame, you need to go to the deviantart.py, plex.py, and fixed.py files to enter the required information (I've tried to provide comments wherever possible).
 
-You also need a channel on NTFY.sh.
+The dashboard is now served locally with Flask so no external notification service is required.
 
 Finally, before launching everything, run these commands in the SSH of the Raspberry:
 
@@ -28,9 +28,10 @@ pip install requests
 pip install plexapi
 ```
 
-To test run :
-```ssh
-python3 main.py
+To start the local dashboard run :
+```bash
+pip install flask
+python3 dashboard.py
 ```
 ### For automation.
 Put the frame.service file in this folder:

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,61 @@
+from flask import Flask, request, send_from_directory, jsonify
+import os
+import json
+
+from OnFrame.download import download
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+WEB_DIR = os.path.join(BASE_DIR, 'OnWeb')
+
+app = Flask(__name__, static_folder=WEB_DIR, static_url_path='')
+
+@app.route('/')
+def index():
+    return send_from_directory(WEB_DIR, 'index.html')
+
+@app.route('/<path:path>')
+def static_proxy(path):
+    return send_from_directory(WEB_DIR, path)
+
+@app.route('/upload.php', methods=['POST'])
+def upload_image():
+    file = request.files.get('image')
+    if not file:
+        return 'No image uploaded', 400
+    file.save(os.path.join(WEB_DIR, 'img.png'))
+    return 'Image uploaded to server.'
+
+@app.route('/update-json.php', methods=['POST'])
+def update_json():
+    data = request.get_json()
+    if data is None:
+        return jsonify(success=False), 400
+    with open(os.path.join(WEB_DIR, 'function.json'), 'w') as f:
+        json.dump(data, f)
+    return jsonify(success=True)
+
+@app.route('/update_tags.php', methods=['POST'])
+def update_tags():
+    data = request.get_json()
+    if data is None:
+        return jsonify(success=False), 400
+    with open(os.path.join(WEB_DIR, 'tags.json'), 'w') as f:
+        json.dump(data, f)
+    return jsonify(success=True)
+
+@app.route('/update_bantag.php', methods=['POST'])
+def update_bantag():
+    data = request.get_json()
+    if data is None:
+        return jsonify(success=False), 400
+    with open(os.path.join(WEB_DIR, 'bantag.json'), 'w') as f:
+        json.dump(data, f)
+    return jsonify(success=True)
+
+@app.route('/new', methods=['POST'])
+def trigger_new():
+    download()
+    return jsonify(success=True)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0')


### PR DESCRIPTION
## Summary
- make download functions read local Web data
- copy fixed images locally
- run dashboard from a Flask app
- start dashboard.py in the service file
- document new local dashboard

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883b71f28888327a51fe507bb3686e3